### PR TITLE
Fix PowerToys Run plugins folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a plugin for [PowerToys Run](https://github.com/microsoft/PowerToys/wiki
 ## Installation
 
 1. Download the latest release of the Winget Plugin from the [releases page](https://github.com/bostrot/PowerToysRunPluginWinget/releases).
-2. Extract the zip file's contents to your PowerToys modules directory (usually `%LOCALAPPDATA%\PowerToys\RunPlugins`).
+2. Extract the zip file's contents to your PowerToys modules directory (usually `%LOCALAPPDATA%\Microsoft\PowerToys\RunPlugins`).
 3. Restart PowerToys.
 
 ## Usage


### PR DESCRIPTION
`%LOCALAPPDATA%\PowerToys\RunPlugins` is incorrect, correct path is `%LOCALAPPDATA%\Microsoft\PowerToys\RunPlugins`